### PR TITLE
build: use the angular-cli version configured in package.json 

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "license": "MIT",
   "angular-cli": {},
   "scripts": {
-    "start": "ng server",
+    "start": "./node_modules/.bin/ng server",
     "postinstall": "typings install",
     "lint": "tslint \"src/**/*.ts\"",
     "format": "clang-format -i -style=file --glob=src/**/*.ts",
-    "test": "ng test",
+    "test": "./node_modules/.bin/ng test",
     "pree2e": "webdriver-manager update",
     "e2e": "protractor"
   },


### PR DESCRIPTION
I noticed npm start was not working, but this change fixes the issue.  This will use the angular-cli version that is configured in package.json, instead of the one installed globally and helps prevent errors at startup due to the global version not supporting mobile.
